### PR TITLE
Minor tweaks to ease profiling for `Vidur` Simulator

### DIFF
--- a/sarathi/benchmark/benchmark_runner.py
+++ b/sarathi/benchmark/benchmark_runner.py
@@ -232,8 +232,8 @@ class BenchmarkRunnerLauncher:
         if self._config.replica_resource_mapping:
             replica_resource_mapping = json.loads(
                 self._config.replica_resource_mapping)
-            print("Replica resource mapping:")
-            print(replica_resource_mapping)
+            logger.info(
+                f"Replica resource mapping: {replica_resource_mapping}")
             return replica_resource_mapping
 
         cluster_resources_keys = list(ray.available_resources().keys())
@@ -273,8 +273,7 @@ class BenchmarkRunnerLauncher:
                 replica_resource_mapping[str(replica_id)].append(
                     available_gpus.pop(0))
 
-        print("Replica resource mapping:")
-        print(replica_resource_mapping)
+        logger.info(f"Replica resource mapping: {replica_resource_mapping}")
 
         return replica_resource_mapping
 

--- a/sarathi/benchmark/capacity_search/main.py
+++ b/sarathi/benchmark/capacity_search/main.py
@@ -15,7 +15,10 @@ import wandb
 
 import yaml
 
+from sarathi.logger import init_logger
 from sarathi.benchmark.capacity_search.search_manager import SearchManager
+
+logger = init_logger(__name__)
 
 
 def get_args():
@@ -67,11 +70,11 @@ if __name__ == "__main__":
 
     os.makedirs(args.output_dir, exist_ok=True)
 
-    print("Starting capacity search", flush=True)
+    logger.info("Starting capacity search", flush=True)
 
     # merge the config with the args
     config.update(vars(args))
-    print(f"Config: {config}", flush=True)
+    logger.info(f"Config: {config}", flush=True)
 
     # store the config and args
     json.dump(config, open(f"{args.output_dir}/config.json", "w"))
@@ -93,4 +96,4 @@ if __name__ == "__main__":
 
     end_time = time.time()
 
-    print(f"Benchmarking took time: {end_time - start_time}", flush=True)
+    logger.info(f"Benchmarking took time: {end_time - start_time}", flush=True)

--- a/sarathi/benchmark/capacity_search/search_manager.py
+++ b/sarathi/benchmark/capacity_search/search_manager.py
@@ -2,6 +2,7 @@ import argparse
 
 import ray
 
+from sarathi.logger import init_logger
 from sarathi.benchmark.capacity_search.capacity_search import CapacitySearch
 from sarathi.benchmark.capacity_search.config import JobConfig
 from sarathi.benchmark.capacity_search.ray_utils import (
@@ -9,6 +10,8 @@ from sarathi.benchmark.capacity_search.ray_utils import (
     RayParallelRunner,
 )
 from sarathi.benchmark.types import ReplicaResourceMapping
+
+logger = init_logger(__name__)
 
 
 def run_search(
@@ -42,7 +45,7 @@ class SearchManager:
         job_configs = JobConfig.generate_job_configs(self.config)
 
         for job_config in job_configs:
-            print(f"Running search for {job_config}")
+            logger.info(f"Running search for {job_config}")
 
         ray_parallel_runner = RayParallelRunner()
 

--- a/sarathi/benchmark/config/config.py
+++ b/sarathi/benchmark/config/config.py
@@ -4,7 +4,10 @@ import os
 
 import yaml
 
+from sarathi.logger import init_logger
 from sarathi.benchmark.constants import DEFAULT_CONFIG_FILE
+
+logger = init_logger(__name__)
 
 
 def custom_bool(val):
@@ -35,6 +38,8 @@ class ConfigParser:
         self._args = None
         self._load_yaml(config_file)
         self._parse_args()
+        logger.info(f"Starting benchmark with config: {self._args}")
+
         self._add_derived_args()
         self._write_yaml_to_file()
 
@@ -47,7 +52,6 @@ class ConfigParser:
         self._args = self._parser.parse_args()
 
     def _add_derived_args(self):
-        print(self._args)
         self._args.output_dir = f"{self._args.output_dir}/{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S-%f')}"
         os.makedirs(self._args.output_dir, exist_ok=True)
 

--- a/sarathi/config.py
+++ b/sarathi/config.py
@@ -512,12 +512,12 @@ def _get_and_verify_max_len(
         derived_max_model_len *= scaling_factor
 
     if max_model_len is None:
-        print(
+        logger.info(
             f"Using the derived maximum model length: {derived_max_model_len}")
         max_model_len = derived_max_model_len
     elif max_model_len > derived_max_model_len:
-        print(f"Applying rope_scaling to the maximum model length: "
-              f"{derived_max_model_len} -> {max_model_len}")
+        logger.info(f"Applying rope_scaling to the maximum model length: "
+                    f"{derived_max_model_len} -> {max_model_len}")
         # force rope_scaling
         scaling_factor = max_model_len / derived_max_model_len
         rope_scaling = {"type": "linear", "factor": scaling_factor}

--- a/sarathi/engine/base_llm_engine.py
+++ b/sarathi/engine/base_llm_engine.py
@@ -126,8 +126,9 @@ class BaseLLMEngine:
 
     def _init_workers_ray(self, **ray_remote_kwargs):
         replica_resource_mapping = self.parallel_config.replica_resource_mapping
-        print("Starting workers with resource mapping:")
-        print(replica_resource_mapping)
+        logger.info(
+            f"Starting workers with resource mapping: {replica_resource_mapping}"
+        )
 
         self.workers: List[RayWorker] = []
 
@@ -167,7 +168,7 @@ class BaseLLMEngine:
         # In case port is already in use, this will fail.
         distributed_init_method = f"tcp://{driver_ip}:{get_random_port()}"
 
-        print(
+        logger.info(
             f"Initializing workers with distributed init method: {distributed_init_method}"
         )
 

--- a/sarathi/model_executor/attention/__init__.py
+++ b/sarathi/model_executor/attention/__init__.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import Enum
 from typing import Union
 
 from sarathi.model_executor.attention.flashinfer_attention_wrapper import FlashinferAttentionWrapper
@@ -7,9 +7,9 @@ from sarathi.model_executor.attention.no_op_attention_wrapper import NoOpAttenti
 
 
 class AttentionBackend(Enum):
-    FLASHINFER = auto()
-    FLASH_ATTENTION = auto()
-    NO_OP = auto()
+    FLASHINFER = "FLASHINFER"
+    FLASH_ATTENTION = "FLASH_ATTENTION"
+    NO_OP = "NO_OP"
 
 
 ATTENTION_BACKEND = AttentionBackend.NO_OP

--- a/sarathi/model_executor/parallel_utils/tensor_parallel/layers.py
+++ b/sarathi/model_executor/parallel_utils/tensor_parallel/layers.py
@@ -15,7 +15,6 @@ from sarathi.model_executor.parallel_utils.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
-from sarathi.metrics.constants import OperationMetrics
 from sarathi.metrics.cuda_timer import CudaTimer
 from .mappings import (
     gather_from_tensor_model_parallel_region,
@@ -340,9 +339,9 @@ class RowParallelLinear(torch.nn.Module):
 
         self.create_weights(params_dtype)
 
-        if not reduce_results and (bias and not skip_bias_add):
-            raise ValueError("When not reduce the results, adding bias to the "
-                             "results can lead to incorrect results")
+        # if not reduce_results and (bias and not skip_bias_add):
+        #     raise ValueError("When not reduce the results, adding bias to the "
+        #                      "results can lead to incorrect results")
 
         if bias:
             self.bias = Parameter(torch.empty(

--- a/sarathi/model_executor/parallel_utils/tensor_parallel/layers.py
+++ b/sarathi/model_executor/parallel_utils/tensor_parallel/layers.py
@@ -11,6 +11,7 @@ import torch.nn.functional as F
 import torch.nn.init as init
 from torch.nn.parameter import Parameter
 
+from sarathi.logger import init_logger
 from sarathi.model_executor.parallel_utils.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -26,6 +27,9 @@ from .utils import (
     divide,
     VocabUtility,
 )
+
+logger = init_logger(__name__)
+
 
 _MODEL_PARALLEL_ATTRIBUTE_DEFAULTS = {'tensor_model_parallel': False,
                                       'partition_dim': -1,
@@ -339,9 +343,9 @@ class RowParallelLinear(torch.nn.Module):
 
         self.create_weights(params_dtype)
 
-        # if not reduce_results and (bias and not skip_bias_add):
-        #     raise ValueError("When not reduce the results, adding bias to the "
-        #                      "results can lead to incorrect results")
+        if not reduce_results and (bias and not skip_bias_add):
+            logger.warning("When not reduce the results, adding bias to the "
+                           "results can lead to incorrect results")
 
         if bias:
             self.bias = Parameter(torch.empty(

--- a/sarathi/transformers_utils/tokenizer.py
+++ b/sarathi/transformers_utils/tokenizer.py
@@ -104,7 +104,7 @@ def detokenize_incrementally(
                 all_input_ids[-6:], skip_special_tokens=skip_special_tokens)
         except ValueError as e:
             new_tokens = ["[UNK]"] * 6
-            print(f"Warning: {e}", flush=True)
+            logger.warning(f"Warning: {e}", flush=True)
 
         output_tokens = new_tokens
         # 5 is an arbitrary value that should work for all
@@ -119,7 +119,7 @@ def detokenize_incrementally(
                 [new_token_id], skip_special_tokens=skip_special_tokens)
         except ValueError as e:
             new_tokens = [prev_tokens[-1]]
-            print(f"Warning: {e}", flush=True)
+            logger.warning(f"Warning: {e}", flush=True)
         output_tokens = prev_tokens + new_tokens
 
     # The prefix text is necessary only to defeat cleanup algorithms in

--- a/sarathi/worker/base_worker.py
+++ b/sarathi/worker/base_worker.py
@@ -86,7 +86,7 @@ class BaseWorker:
         # This env var set by Ray causes exceptions with graph building.
         os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
 
-        print(f"Worker {self.rank} is using device {self.local_rank}")
+        logger.info(f"Worker {self.rank} is using device {self.local_rank}")
         self.device = torch.device(f"cuda:{self.local_rank}")
         torch.cuda.set_device(self.device)
 


### PR DESCRIPTION
# Changelog

1. Explicitly set string values for different attention backends for easier portability.
2. Remove check to not add bias when an all_reduce is not done before it.
For compute time profiling of linear layers, we disable communication, so all_reduce is not called. However, bias is still added to include the add time. So, we need to allow add bias even when all_reduce is not done before it.

# Test Plan

This change doesn't affect the functionality of the inference system.