### PR TITLE
Add OSDI Experiment Folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Sarathi-Serve has been tested with CUDA 12.1 on A100 and A40 GPUs.
 ### Clone repository
 
 ```sh
-git clone https://msri@dev.azure.com/msri/AI-Infrastructure/_git/llm-batching
+git clone https://github.com/microsoft/sarathi-serve.git
 ```
 
 ### Create mamba environment


### PR DESCRIPTION
# Changelog

1. Add the folder `osdi-experiments` which contains the scripts to run all the experiments in the [paper](https://arxiv.org/abs/2403.02310). As there is some difference between the arxiv and the paper submitted to OSDI, the figure numbers are not exactly the same.